### PR TITLE
Pin AutoPkg action and configure command

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -1,9 +1,9 @@
-name: AutoPkg
+name: 'AutoPkg → Fleet → PR'
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,35 +14,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  autopkg:
+  build-publish:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Checkout overrides
+      - name: Checkout runner
+        uses: actions/checkout@v4
+
+      - name: Checkout overrides (read-only)
         uses: actions/checkout@v4
         with:
           repository: ${{ secrets.OVERRIDES_REPO }}
           ref: ${{ secrets.OVERRIDES_REF }}
           path: overrides
-      - name: Setup AutoPkg
-        uses: autopkg/setup-autopkg-actions@v1
-      - name: Install dependencies
+          persist-credentials: false
+
+      - name: Setup AutoPkg (pin valid tag)
+        uses: autopkg/setup-autopkg-actions@v0.1.2
+
+      - name: Tooling
         run: |
           brew install jq
-          python3 -m pip install --quiet ruamel.yaml pyyaml
-      - name: Add recipe repos
-        run: |
-          autopkg repo-add autopkg/recipes
-          autopkg repo-add homebysix/recipes
-      - name: Verify recipe trust
-        run: |
-          set -e
-          while read -r recipe; do
-            [[ -n "$recipe" ]] || continue
-            autopkg verify-trust "$recipe"
-          done < overrides/recipe-lists/darwin-prod.txt
-      - name: Run AutoPkg
+          python3 -m pip install --upgrade pip ruamel.yaml
+        # Expose the correct AutoPkg CLI for THIS runner environment.
         env:
+          AUTOPKG_CMD: python autopkg/Code/autopkg
+
+      - name: Add upstream recipe repos
+        env:
+          AUTOPKG_CMD: python autopkg/Code/autopkg
+        run: |
+          set -euo pipefail
+          $AUTOPKG_CMD repo-add https://github.com/autopkg/recipes || true
+          $AUTOPKG_CMD repo-add https://github.com/homebysix/recipes || true
+          $AUTOPKG_CMD repo-list
+
+      - name: Verify trust for recipes in overrides list
+        env:
+          AUTOPKG_CMD: python autopkg/Code/autopkg
+        run: |
+          set -euo pipefail
+          while read -r r; do
+            echo "Verifying trust: $r"
+            $AUTOPKG_CMD verify-trust-info "overrides/overrides/${r}.recipe" || exit 1
+          done < overrides/recipe-lists/darwin-prod.txt
+
+      - name: Run AutoPkg + upload to Fleet
+        env:
+          AUTOPKG_CMD: python autopkg/Code/autopkg
           FLEET_URL: ${{ secrets.FLEET_URL }}
           FLEET_API_TOKEN: ${{ secrets.FLEET_API_TOKEN }}
         run: scripts/run_autopkg.sh
@@ -56,6 +74,7 @@ jobs:
           git config user.name "autopkg-bot"
           git config user.email "autopkg-bot@users.noreply.github.com"
           git checkout "${{ secrets.GITOPS_DEFAULT_BRANCH }}"
+
       - name: Update GitOps and open PRs
         env:
           GITOPS_REPO: ${{ secrets.GITOPS_REPO }}
@@ -84,6 +103,7 @@ jobs:
             echo "$pr_url" >> ../pr_urls.txt
             cd ..
           done
+
       - name: PR Summary
         run: |
           echo '## Pull Requests' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository contains a GitHub Actions workflow and helper scripts to run [AutoPkg](https://autopkg.github.io/autopkg/) recipes, upload packages to [Fleet](https://fleetdm.com/), and open pull requests against a separate GitOps repository.
 
+AutoPkg is invoked differently depending on the environment:
+
+- Locally, call the `autopkg` CLI directly (for example when installed via Homebrew).
+- In CI, the workflow uses `python autopkg/Code/autopkg` from the setup action and exposes it via the `AUTOPKG_CMD` environment variable so scripts behave the same.
+
 ## Required secrets
 
 Set these secrets in the repository settings so the workflow can access external services:

--- a/scripts/run_autopkg.sh
+++ b/scripts/run_autopkg.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+AUTOPKG_CMD="${AUTOPKG_CMD:-autopkg}"
 
 MAP_FILE="config/recipe-map.yml"
 OUT_DIR="out"
@@ -33,8 +34,8 @@ PY
 while IFS= read -r recipe; do
   [[ -n "$recipe" ]] || continue
   echo "Running $recipe"
-  autopkg run "$recipe" --report-plist=report.plist -v
-  PKG=$(/usr/libexec/PlistBuddy -c 'Print :report:packages:0:path' report.plist)
+  $AUTOPKG_CMD run "overrides/overrides/${recipe}.recipe" --report-plist=report.plist -v
+  PKG=$(/usr/libexec/PlistBuddy -c 'Print :results:packages:0:pathname' report.plist)
   read TEAM SELF_SERVICE < <(read_map "$recipe")
   RESPONSE=$(curl -sS -X POST "$FLEET_URL/api/v1/fleet/software/package" \
     -H "Authorization: Bearer $FLEET_API_TOKEN" -H "kbn-xsrf: true" \


### PR DESCRIPTION
## Summary
- pin setup-autopkg action to v0.1.2 and run AutoPkg via exported AUTOPKG_CMD
- allow scripts to accept custom AutoPkg command
- document local vs CI AutoPkg invocation

## Testing
- `bash -n scripts/run_autopkg.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5866c348321b462719f6f386c46