### PR TITLE
chore: use setup-autopkg composite

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   build-publish:
     runs-on: macos-latest
+    env:
+      AUTOPKG_CMD: python autopkg/Code/autopkg
     steps:
       - name: Checkout runner
         uses: actions/checkout@v4
@@ -28,37 +30,16 @@ jobs:
           ref: ${{ secrets.OVERRIDES_REF }}
           path: overrides
           persist-credentials: false
-      - name: Install AutoPkg (official pkg) + tooling
-        run: |
-          set -euo pipefail
-          brew install jq
-          python3 -m pip install --upgrade pip ruamel.yaml
-          # Fetch latest AutoPkg release pkg URL
-          URL="$(
-            curl -fsSL \
-              https://api.github.com/repos/autopkg/autopkg/releases/latest |
-            jq -r '.assets[] |
-              select(.name | endswith(".pkg")) |
-              .browser_download_url'
-          )"
-          echo "AutoPkg pkg: $URL"
-          curl -fsSL "$URL" -o /tmp/autopkg.pkg
-          sudo installer -pkg /tmp/autopkg.pkg -target /
-          autopkg version
+      - name: Setup AutoPkg
+        uses: autopkg/setup-autopkg-actions@v0.1.2
 
-      - name: Ensure autopkgserver is running
-        run: |
-          set -euo pipefail
-          # On GH macOS runners sudo is passwordless; load if not already.
-          if ! sudo launchctl list |
-            grep -q com.github.autopkg.autopkgserver; then
-            sudo launchctl bootstrap system \
-              /Library/LaunchDaemons/com.github.autopkg.autopkgserver.plist
-          fi
-          sudo launchctl print system/com.github.autopkg.autopkgserver || true
+      - name: Install jq
+        run: brew install jq
+
+      - name: Check AutoPkg version
+        run: $AUTOPKG_CMD version
 
       - name: Add upstream recipe repos
-        env: { AUTOPKG_CMD: autopkg }  # yamllint disable-line rule:braces
         run: |
           set -euo pipefail
           $AUTOPKG_CMD repo-add https://github.com/autopkg/recipes || true
@@ -66,7 +47,6 @@ jobs:
           $AUTOPKG_CMD repo-list
 
       - name: Verify trust for recipes in overrides list
-        env: { AUTOPKG_CMD: autopkg }  # yamllint disable-line rule:braces
         run: |
           set -euo pipefail
           mapfile -t RECIPES < <(
@@ -89,7 +69,6 @@ jobs:
 
       - name: Run AutoPkg + upload to Fleet
         env:
-          AUTOPKG_CMD: autopkg
           FLEET_URL: ${{ secrets.FLEET_URL }}
           FLEET_API_TOKEN: ${{ secrets.FLEET_API_TOKEN }}
         run: |
@@ -150,7 +129,7 @@ jobs:
             git checkout "$GITOPS_DEFAULT_BRANCH"
             git pull --ff-only
             git checkout -b "$branch"
-            python3 ../scripts/update_gitops.py \
+            python ../scripts/update_gitops.py \
               --gitops-dir . \
               --json "../$json" \
               --teams workstations,workstations-canary


### PR DESCRIPTION
## Summary
- use autopkg/setup-autopkg-actions composite
- call python-based `AUTOPKG_CMD`

## Testing
- `pre-commit run --files .github/workflows/autopkg.yml` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7e22fe883218e4fc5702778039e