### PR TITLE
Use while loop for recipe list parsing in trust verification step

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -49,9 +49,10 @@ jobs:
       - name: Verify trust for recipes in overrides list
         run: |
           set -euo pipefail
-          mapfile -t RECIPES < <(
-            grep -Ev '^\s*(#|$)' overrides/recipe-lists/darwin-prod.txt || true
-          )
+          RECIPES=()
+          while IFS= read -r line; do
+            RECIPES+=("$line")
+          done < <(grep -Ev '^\s*(#|$)' overrides/recipe-lists/darwin-prod.txt || true)
           if (( ${#RECIPES[@]} == 0 )); then
             echo "No recipes found in overrides/recipe-lists/darwin-prod.txt"
             exit 1


### PR DESCRIPTION
## Summary
- replace `mapfile` with `while read` loop for collecting recipes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeea0d7088321a74f3550e575a9ec