### PR TITLE
Start autopkgserver before running recipes

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check AutoPkg version
         run: $AUTOPKG_CMD version
 
+      - name: Start autopkgserver
+        run: sudo $AUTOPKG_CMD install
+
       - name: Add upstream recipe repos
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- start the autopkgserver in workflow before any autopkg invocations

## Testing
- `yamllint .github/workflows/autopkg.yml`
- `python /tmp/autopkg/Code/autopkg --help` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe12c22483218c5c3d945c725beb