### PR TITLE
Add root execution check to run_autopkg.sh

### DIFF
--- a/scripts/run_autopkg.sh
+++ b/scripts/run_autopkg.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [[ $EUID -eq 0 ]]; then
+  echo "Do not run this script as root." >&2
+  exit 1
+fi
 set -euo pipefail
 AUTOPKG_CMD="${AUTOPKG_CMD:-autopkg}"
 


### PR DESCRIPTION
## Summary
- abort when run_autopkg.sh is executed as root to ensure AutoPkg runs unprivileged

## Testing
- `shellcheck scripts/run_autopkg.sh`
- `bash -n scripts/run_autopkg.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be0178b4c48321b17a283e819d1b72