### PR TITLE
Update trust for Github Desktop Google Chrome

### DIFF
--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -7,8 +7,9 @@ ParentRecipe: com.github.kitzy.fleet.GithubDesktop
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      path: ''
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
+      sha256_hash: 6f9777cfac29cd6638bce617a077a12cd9bbffe63ff29f023d5268ed41068eee
   parent_recipes:
     com.github.homebysix.download.GitHubDesktop:
       git_hash: 929f09a8dc248349e9ce35f7d519c253298317d1
@@ -19,7 +20,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.pkg.recipe
       sha256_hash: 8bfa208120d6372efa61b1043046f6a08ef896e0d4c07a0853cd3f532026c798
     com.github.kitzy.fleet.GithubDesktop:
-      git_hash: 0dbbca924e26bba58c4bc2780098dbefd5bee94f
-      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Github
-        Desktop/GithubDesktop.fleet.recipe.yaml
+      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GithubDesktop.fleet.recipe.yaml
       sha256_hash: 5a600c2213a39cfe7a32e8dc09500120c5a41c9c16d0dcd29b73dd1ae94360ff

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -6,8 +6,9 @@ ParentRecipe: com.github.kitzy.fleet.GoogleChrome
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      path: ''
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
+      sha256_hash: 6f9777cfac29cd6638bce617a077a12cd9bbffe63ff29f023d5268ed41068eee
   parent_recipes:
     com.github.autopkg.download.googlechrome:
       git_hash: 6f8bd33df3f7ab53eb679749eae8f04227790652
@@ -18,7 +19,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.pkg.recipe
       sha256_hash: 5acdf716353ccc57f021008bc5b4b55a5cb4e578e0f96864b71d4d2d29742ec8
     com.github.kitzy.fleet.GoogleChrome:
-      git_hash: 0dbbca924e26bba58c4bc2780098dbefd5bee94f
-      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google
-        Chrome/GoogleChrome.fleet.recipe.yaml
+      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GoogleChrome.fleet.recipe.yaml
       sha256_hash: 03d1508fe03b9da63d1609b3635f837312e6bbc694749563085aaa022e6e7364


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
