### PR TITLE
Update trust for Github Desktop Google Chrome

### DIFF
--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -7,9 +7,9 @@ ParentRecipe: com.github.kitzy.fleet.GithubDesktop
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      git_hash: 2d7731919b922cd20714636fc2d00a22a61351e9
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: 6f9777cfac29cd6638bce617a077a12cd9bbffe63ff29f023d5268ed41068eee
+      sha256_hash: 1a3cd8fb10e64863b6407f276b90a3d836d22c4fa850306c37c34fe75ac35914
   parent_recipes:
     com.github.homebysix.download.GitHubDesktop:
       git_hash: 929f09a8dc248349e9ce35f7d519c253298317d1

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -6,9 +6,9 @@ ParentRecipe: com.github.kitzy.fleet.GoogleChrome
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: ab86416072b423f9d9afb4f6bc158cc7944e3e03
+      git_hash: 2d7731919b922cd20714636fc2d00a22a61351e9
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: 6f9777cfac29cd6638bce617a077a12cd9bbffe63ff29f023d5268ed41068eee
+      sha256_hash: 1a3cd8fb10e64863b6407f276b90a3d836d22c4fa850306c37c34fe75ac35914
   parent_recipes:
     com.github.autopkg.download.googlechrome:
       git_hash: 6f8bd33df3f7ab53eb679749eae8f04227790652


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index eb450a9..6970b0b 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -464,6 +464,7 @@ class FleetGitOpsUploader(Processor):
             post_install_script: str,
         ) -> dict:
             url = f"{base_url}/api/v1/fleet/software/package"
    +        self.output(f"Uploading file to Fleet: {pkg_path}")
             # API rules: only one of include/exclude
             if labels_include_any and labels_exclude_any:
                 raise ProcessorError("Only one of labels_include_any or labels_exclude_any may be specified.")
    @@ -523,13 +524,16 @@ class FleetGitOpsUploader(Processor):
                     self.output(
                         "Package already exists in Fleet (409 Conflict). Calculating SHA-256 locally."
                     )
    +                self.output(f"Calculating SHA-256 for: {pkg_path}")
                     h = hashlib.sha256()
                     with open(pkg_path, "rb") as f:
                         for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
                             h.update(chunk)
    +                digest = h.hexdigest()
    +                self.output(f"SHA-256: {digest}")
                     return {
                         "software_package": {
    -                        "hash_sha256": h.hexdigest(),
    +                        "hash_sha256": digest,
                             "version": version,
                             "title_id": None,
                             "installer_id": None,
    commit 2d7731919b922cd20714636fc2d00a22a61351e9
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sun Sep 14 19:13:28 2025 -0400
    
        Log file paths and hashes during Fleet upload
    

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index eb450a9..6970b0b 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -464,6 +464,7 @@ class FleetGitOpsUploader(Processor):
             post_install_script: str,
         ) -> dict:
             url = f"{base_url}/api/v1/fleet/software/package"
    +        self.output(f"Uploading file to Fleet: {pkg_path}")
             # API rules: only one of include/exclude
             if labels_include_any and labels_exclude_any:
                 raise ProcessorError("Only one of labels_include_any or labels_exclude_any may be specified.")
    @@ -523,13 +524,16 @@ class FleetGitOpsUploader(Processor):
                     self.output(
                         "Package already exists in Fleet (409 Conflict). Calculating SHA-256 locally."
                     )
    +                self.output(f"Calculating SHA-256 for: {pkg_path}")
                     h = hashlib.sha256()
                     with open(pkg_path, "rb") as f:
                         for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
                             h.update(chunk)
    +                digest = h.hexdigest()
    +                self.output(f"SHA-256: {digest}")
                     return {
                         "software_package": {
    -                        "hash_sha256": h.hexdigest(),
    +                        "hash_sha256": digest,
                             "version": version,
                             "title_id": None,
                             "installer_id": None,
    commit 2d7731919b922cd20714636fc2d00a22a61351e9
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sun Sep 14 19:13:28 2025 -0400
    
        Log file paths and hashes during Fleet upload
    
