### PR TITLE
Update trust for Github Desktop Google Chrome

### DIFF
--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -7,9 +7,9 @@ ParentRecipe: com.github.kitzy.fleet.GithubDesktop
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: 12c2ae28bfa58080c2554833d4b3ecef9ef065e6
+      git_hash: cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: a95b8002ca86b67bf45d4ae74c0d6c36447aa4ff081ca5195f4a011bd9e322aa
+      sha256_hash: 5e55c5a9185e4d6ee978c52b480820596c6cc791ebdd966a098d14bfc1ef0cbb
   parent_recipes:
     com.github.homebysix.download.GitHubDesktop:
       git_hash: 929f09a8dc248349e9ce35f7d519c253298317d1

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -6,9 +6,9 @@ ParentRecipe: com.github.kitzy.fleet.GoogleChrome
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: 12c2ae28bfa58080c2554833d4b3ecef9ef065e6
+      git_hash: cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: a95b8002ca86b67bf45d4ae74c0d6c36447aa4ff081ca5195f4a011bd9e322aa
+      sha256_hash: 5e55c5a9185e4d6ee978c52b480820596c6cc791ebdd966a098d14bfc1ef0cbb
   parent_recipes:
     com.github.autopkg.download.googlechrome:
       git_hash: 6f8bd33df3f7ab53eb679749eae8f04227790652


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index 8053d79..9cb676d 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -297,15 +297,23 @@ class FleetGitOpsUploader(Processor):
             )
             if not upload_info:
                 raise ProcessorError("Fleet package upload failed; no data returned")
    +        
    +        # Check for graceful exit case (409 Conflict)
    +        if upload_info.get("package_exists"):
    +            self.output("Package already exists in Fleet. Exiting gracefully without GitOps operations.")
    +            # Set minimal output variables for graceful exit
    +            self.env["fleet_title_id"] = None
    +            self.env["fleet_installer_id"] = None  
    +            self.env["git_branch"] = ""
    +            self.env["pull_request_url"] = ""
    +            return
    +        
             software_package = upload_info.get("software_package", {})
             title_id = software_package.get("title_id")
             installer_id = software_package.get("installer_id")
             hash_sha256 = software_package.get("hash_sha256")
             returned_version = software_package.get("version") or version
     
    -        if title_id is None or installer_id is None:
    -            self.output("Package already exists in Fleet; proceeding with locally computed hash.")
    -
             # Prepare repo in a temp dir
             with tempfile.TemporaryDirectory() as tmpdir:
                 repo_dir = Path(tmpdir) / "repo"
    @@ -366,9 +374,19 @@ class FleetGitOpsUploader(Processor):
                 if team_yaml_modified:
                     self._git(["add", str(team_yaml_abs)], cwd=repo_dir)
     
    -            # If nothing to commit, we still push branch (idempotent PRs are okay)
    +            # Check if changes need to be committed
                 commit_msg = f"feat(software): {software_title} {returned_version} [{software_slug}]"
    -            self._git_safe_commit(commit_msg, cwd=repo_dir)
    +            commit_made = self._git_safe_commit(commit_msg, cwd=repo_dir)
    +
    +            # Check if any changes were actually committed
    +            if not commit_made:
    +                self.output("No changes detected, skipping branch push and PR creation.")
    +                # Set output variables to indicate no action was taken
    +                self.env["fleet_title_id"] = title_id
    +                self.env["fleet_installer_id"] = installer_id
    +                self.env["git_branch"] = ""
    +                self.env["pull_request_url"] = ""
    +                return
     
                 # Push
                 self._git(["push", "--set-upstream", "origin", branch_name], cwd=repo_dir)
    @@ -414,6 +432,8 @@ class FleetGitOpsUploader(Processor):
             status = self._git(["status", "--porcelain"], cwd=cwd)
             if status:
                 self._git(["commit", "-m", message], cwd=cwd)
    +            return True
    +        return False
     
         @staticmethod
         def _pr_body(
    @@ -520,35 +540,11 @@ class FleetGitOpsUploader(Processor):
                     status = resp.getcode()
             except urllib.error.HTTPError as e:
                 if e.code == 409:
    -                # Package already exists in Fleet - compute hash locally and return minimal info
    +                # Package already exists in Fleet - return special marker for graceful exit
                     self.output(
    -                    "Package already exists in Fleet (409 Conflict). Calculating SHA-256 locally."
    +                    "Package already exists in Fleet (409 Conflict). Exiting gracefully."
                     )
    -                self.output(f"Calculating SHA-256 for: {pkg_path}")
    -
    -
    -                # Hash in chunks
    -                h_chunked = hashlib.sha256()
    -                with open(pkg_path, "rb") as f:
    -                    for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
    -                        h_chunked.update(chunk)
    -                digest_chunked = h_chunked.hexdigest()
    -                self.output(f"SHA-256 (chunked): {digest_chunked}")
    -
    -                # Hash in one read
    -                with open(pkg_path, "rb") as f:
    -                    digest_single = hashlib.sha256(f.read()).hexdigest()
    -                self.output(f"SHA-256 (single read): {digest_single}")
    -
    -                digest = digest_chunked
    -                return {
    -                    "software_package": {
    -                        "hash_sha256": digest,
    -                        "version": version,
    -                        "title_id": None,
    -                        "installer_id": None,
    -                    }
    -                }
    +                return {"package_exists": True}
                 raise ProcessorError(f"Fleet upload failed: {e.code} {e.read().decode()}")
             if status != 200:
                 raise ProcessorError(f"Fleet upload failed: {status} {resp_body.decode()}")
    commit cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
    Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
    Date:   Wed Sep 17 23:26:21 2025 +0000
    
        Fix: Skip branch push and PR creation when no changes detected
        
        Co-authored-by: kitzy <3417399+kitzy@users.noreply.github.com>
    
    commit 76b78b9dd3750e5158c80d82058e6a0ba0d9e0ad
    Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
    Date:   Wed Sep 17 23:00:23 2025 +0000
    
        Implement graceful exit on 409 Conflict without local hash computation
        
        Co-authored-by: kitzy <3417399+kitzy@users.noreply.github.com>
    

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index 8053d79..9cb676d 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -297,15 +297,23 @@ class FleetGitOpsUploader(Processor):
             )
             if not upload_info:
                 raise ProcessorError("Fleet package upload failed; no data returned")
    +        
    +        # Check for graceful exit case (409 Conflict)
    +        if upload_info.get("package_exists"):
    +            self.output("Package already exists in Fleet. Exiting gracefully without GitOps operations.")
    +            # Set minimal output variables for graceful exit
    +            self.env["fleet_title_id"] = None
    +            self.env["fleet_installer_id"] = None  
    +            self.env["git_branch"] = ""
    +            self.env["pull_request_url"] = ""
    +            return
    +        
             software_package = upload_info.get("software_package", {})
             title_id = software_package.get("title_id")
             installer_id = software_package.get("installer_id")
             hash_sha256 = software_package.get("hash_sha256")
             returned_version = software_package.get("version") or version
     
    -        if title_id is None or installer_id is None:
    -            self.output("Package already exists in Fleet; proceeding with locally computed hash.")
    -
             # Prepare repo in a temp dir
             with tempfile.TemporaryDirectory() as tmpdir:
                 repo_dir = Path(tmpdir) / "repo"
    @@ -366,9 +374,19 @@ class FleetGitOpsUploader(Processor):
                 if team_yaml_modified:
                     self._git(["add", str(team_yaml_abs)], cwd=repo_dir)
     
    -            # If nothing to commit, we still push branch (idempotent PRs are okay)
    +            # Check if changes need to be committed
                 commit_msg = f"feat(software): {software_title} {returned_version} [{software_slug}]"
    -            self._git_safe_commit(commit_msg, cwd=repo_dir)
    +            commit_made = self._git_safe_commit(commit_msg, cwd=repo_dir)
    +
    +            # Check if any changes were actually committed
    +            if not commit_made:
    +                self.output("No changes detected, skipping branch push and PR creation.")
    +                # Set output variables to indicate no action was taken
    +                self.env["fleet_title_id"] = title_id
    +                self.env["fleet_installer_id"] = installer_id
    +                self.env["git_branch"] = ""
    +                self.env["pull_request_url"] = ""
    +                return
     
                 # Push
                 self._git(["push", "--set-upstream", "origin", branch_name], cwd=repo_dir)
    @@ -414,6 +432,8 @@ class FleetGitOpsUploader(Processor):
             status = self._git(["status", "--porcelain"], cwd=cwd)
             if status:
                 self._git(["commit", "-m", message], cwd=cwd)
    +            return True
    +        return False
     
         @staticmethod
         def _pr_body(
    @@ -520,35 +540,11 @@ class FleetGitOpsUploader(Processor):
                     status = resp.getcode()
             except urllib.error.HTTPError as e:
                 if e.code == 409:
    -                # Package already exists in Fleet - compute hash locally and return minimal info
    +                # Package already exists in Fleet - return special marker for graceful exit
                     self.output(
    -                    "Package already exists in Fleet (409 Conflict). Calculating SHA-256 locally."
    +                    "Package already exists in Fleet (409 Conflict). Exiting gracefully."
                     )
    -                self.output(f"Calculating SHA-256 for: {pkg_path}")
    -
    -
    -                # Hash in chunks
    -                h_chunked = hashlib.sha256()
    -                with open(pkg_path, "rb") as f:
    -                    for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
    -                        h_chunked.update(chunk)
    -                digest_chunked = h_chunked.hexdigest()
    -                self.output(f"SHA-256 (chunked): {digest_chunked}")
    -
    -                # Hash in one read
    -                with open(pkg_path, "rb") as f:
    -                    digest_single = hashlib.sha256(f.read()).hexdigest()
    -                self.output(f"SHA-256 (single read): {digest_single}")
    -
    -                digest = digest_chunked
    -                return {
    -                    "software_package": {
    -                        "hash_sha256": digest,
    -                        "version": version,
    -                        "title_id": None,
    -                        "installer_id": None,
    -                    }
    -                }
    +                return {"package_exists": True}
                 raise ProcessorError(f"Fleet upload failed: {e.code} {e.read().decode()}")
             if status != 200:
                 raise ProcessorError(f"Fleet upload failed: {status} {resp_body.decode()}")
    commit cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
    Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
    Date:   Wed Sep 17 23:26:21 2025 +0000
    
        Fix: Skip branch push and PR creation when no changes detected
        
        Co-authored-by: kitzy <3417399+kitzy@users.noreply.github.com>
    
    commit 76b78b9dd3750e5158c80d82058e6a0ba0d9e0ad
    Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
    Date:   Wed Sep 17 23:00:23 2025 +0000
    
        Implement graceful exit on 409 Conflict without local hash computation
        
        Co-authored-by: kitzy <3417399+kitzy@users.noreply.github.com>
    
