### PR TITLE
Enhance PR reviewer assignment in autopkg workflow

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -33,6 +33,7 @@ jobs:
       AUTOPKG_URL: "https://github.com/autopkg/autopkg/releases/download/v2.7.6/autopkg-2.7.6.pkg"
       GITHUB_TOKEN: ${{ secrets.AUTOPKG_RUNNER_GITHUB_TOKEN }}
       FLEET_GITOPS_GITHUB_TOKEN: ${{ secrets.FLEET_GITOPS_GITHUB_TOKEN }}
+      PR_REVIEWER: ${{ secrets.AUTOPKG_PR_REVIEWER }}
     steps:
     - name: Checkout AutoPkg recipes
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3 Pin SHA1 hash instead of version
@@ -107,7 +108,7 @@ jobs:
         SLACK_WEBHOOK_URL: None
 
     - name: Create Trust Info pull request
-      if: env.TITLE
+      if: ${{ env.TITLE }}
       id: create_pr
       run: |
         export BRANCH_NAME=trust-info-`date +'%Y-%m-%d'`
@@ -128,10 +129,16 @@ jobs:
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
     - name: Request PR review if reviewer set
-      if: ${{ github.event.inputs.pr_reviewer != '' && steps.create_pr.outputs.pr_number != '' }}
+      if: steps.create_pr.outputs.pr_number != ''
       run: |
-        curl -s -X POST \
-          -H "Authorization: Bearer $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pr_number }}/requested_reviewers \
-          -d '{"reviewers":["${{ github.event.inputs.pr_reviewer }}"]}'
+        REVIEWER="${{ github.event.inputs.pr_reviewer }}"
+        if [ -z "$REVIEWER" ]; then
+          REVIEWER="$PR_REVIEWER"
+        fi
+        if [ -n "$REVIEWER" ]; then
+          curl -s -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pr_number }}/requested_reviewers \
+            -d "{\"reviewers\":[\"$REVIEWER\"]}"
+        fi


### PR DESCRIPTION
Adds support for a default PR reviewer via the PR_REVIEWER secret and improves logic to assign a reviewer if not provided in workflow inputs. Also fixes the conditional for creating a Trust Info pull request.