### PR TITLE
Add Caffeine Fleet recipe override and update repo list

### DIFF
--- a/overrides/Caffeine.fleet.recipe.yaml
+++ b/overrides/Caffeine.fleet.recipe.yaml
@@ -1,0 +1,4 @@
+Identifier: local.fleet.Caffeine
+Input:
+  NAME: Caffeine
+ParentRecipe: com.github.kitzy.fleet.Caffeine

--- a/repo_list.txt
+++ b/repo_list.txt
@@ -2,4 +2,5 @@ https://github.com/autopkg/recipes
 https://github.com/hjuutilainen/autopkg-virustotalanalyzer
 https://github.com/autopkg/grahampugh-recipes
 https://github.com/autopkg/homebysix-recipes
+https://github.com/autopkg/peetinc-recipes
 https://github.com/kitzy/fleet-autopkg-recipes


### PR DESCRIPTION
Added a new override for the Caffeine Fleet recipe and included the peetinc-recipes repository in repo_list.txt to expand available recipes.