### PR TITLE
Update trust for Caffeine

### DIFF
--- a/overrides/Caffeine.fleet.recipe.yaml
+++ b/overrides/Caffeine.fleet.recipe.yaml
@@ -2,3 +2,22 @@ Identifier: local.fleet.Caffeine
 Input:
   NAME: Caffeine
 ParentRecipe: com.github.kitzy.fleet.Caffeine
+ParentRecipeTrustInfo:
+  non_core_processors:
+    FleetGitOpsUploader:
+      git_hash: 886a2f2b404c2707009653f7c00ee1e602ae0e79
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
+      sha256_hash: 40fb09f84311c0e19d29aed27f86aacefcc13f377510a491a8db4ab736f438f3
+  parent_recipes:
+    com.github.homebysix.pkg.Caffeine:
+      git_hash: 13fe4fea20b645bfd9264124c0b96bdc1b9f6687
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Caffeine/Caffeine.pkg.recipe
+      sha256_hash: ac31ef8b28f1f586aec3b788ae4c74278d174c692e1e1063c9f5ebea9cc9fa48
+    com.github.kitzy.fleet.Caffeine:
+      git_hash: 780dd02e29490e3983f6ec77a56ef98ac6fc4442
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Caffeine.fleet.recipe.yaml
+      sha256_hash: b286f364ef1c3687277425e0b24a5d50d7eb7accb1875d4675a9e2fc7663f965
+    com.github.peetinc.download.Caffeine:
+      git_hash: 422113e2c5b9eab704721efed3aee4a9b6882069
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.peetinc-recipes/Caffeine/Caffeine.download.recipe
+      sha256_hash: 11685cd8cbf44b39731a8fdae48c266dd84d5b3fb8c00de43f5ed8d0007eadc7


### PR DESCRIPTION
overrides/Caffeine.fleet.recipe.yaml: FAILED
    No trust information present.
    Audit the parent recipe, then run:
    	autopkg update-trust-info overrides/Caffeine.fleet.recipe.yaml
