### PR TITLE
Update trust for Github Desktop Google Chrome

### DIFF
--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -7,9 +7,9 @@ ParentRecipe: com.github.kitzy.fleet.GithubDesktop
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
+      git_hash: 886a2f2b404c2707009653f7c00ee1e602ae0e79
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: 5e55c5a9185e4d6ee978c52b480820596c6cc791ebdd966a098d14bfc1ef0cbb
+      sha256_hash: 40fb09f84311c0e19d29aed27f86aacefcc13f377510a491a8db4ab736f438f3
   parent_recipes:
     com.github.homebysix.download.GitHubDesktop:
       git_hash: 929f09a8dc248349e9ce35f7d519c253298317d1

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -6,9 +6,9 @@ ParentRecipe: com.github.kitzy.fleet.GoogleChrome
 ParentRecipeTrustInfo:
   non_core_processors:
     FleetGitOpsUploader:
-      git_hash: cabc0d3843f7cd9bb23dab53d2e738c04a3cf9e7
+      git_hash: 886a2f2b404c2707009653f7c00ee1e602ae0e79
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
-      sha256_hash: 5e55c5a9185e4d6ee978c52b480820596c6cc791ebdd966a098d14bfc1ef0cbb
+      sha256_hash: 40fb09f84311c0e19d29aed27f86aacefcc13f377510a491a8db4ab736f438f3
   parent_recipes:
     com.github.autopkg.download.googlechrome:
       git_hash: 6f8bd33df3f7ab53eb679749eae8f04227790652


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index 9cb676d..7cb5534 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -178,6 +178,12 @@ class FleetGitOpsUploader(Processor):
                 "description": "List of GitHub PR labels to apply.",
             },
     
    +        "PR_REVIEWER": {
    +            "required": False,
    +            "default": "",
    +            "description": "GitHub username to assign as PR reviewer.",
    +        },
    +
             # Slug / naming
             "software_slug": {
                 "required": False,
    @@ -272,7 +278,11 @@ class FleetGitOpsUploader(Processor):
                     "GitHub token not provided (github_token or FLEET_GITOPS_GITHUB_TOKEN env)."
                 )
             pr_labels = list(self.env.get("pr_labels", []))
    +
    +
             branch_prefix = self.env.get("branch_prefix", "").strip()
    +        pr_reviewer = self.env.get("PR_REVIEWER", "") or os.environ.get("PR_REVIEWER", "")
    +        pr_reviewer = pr_reviewer.strip()
     
             # Slug
             software_slug = self.env.get("software_slug", "").strip() or self._slugify(software_title)
    @@ -392,6 +402,7 @@ class FleetGitOpsUploader(Processor):
                 self._git(["push", "--set-upstream", "origin", branch_name], cwd=repo_dir)
     
             # Open PR
    +
             pr_url = self._open_pull_request(
                 github_repo=github_repo,
                 github_token=github_token,
    @@ -400,6 +411,7 @@ class FleetGitOpsUploader(Processor):
                 title=f"{software_title} {returned_version}",
                 body=self._pr_body(software_title, returned_version, software_slug, title_id, installer_id),
                 labels=pr_labels,
    +            reviewer=pr_reviewer,
             )
     
             # Outputs
    @@ -653,6 +665,7 @@ class FleetGitOpsUploader(Processor):
             title: str,
             body: str,
             labels: list[str],
    +        reviewer: str = "",
         ) -> str:
             api = f"https://api.github.com/repos/{github_repo}/pulls"
             headers = {
    @@ -689,6 +702,16 @@ class FleetGitOpsUploader(Processor):
                 except urllib.error.HTTPError:
                     pass
     
    +        # Assign reviewer if provided
    +        if reviewer and pr_url and "number" in pr:
    +            reviewers_api = f"https://api.github.com/repos/{github_repo}/pulls/{pr['number']}/requested_reviewers"
    +            reviewers_data = json.dumps({"reviewers": [reviewer]}).encode()
    +            reviewers_req = urllib.request.Request(reviewers_api, data=reviewers_data, headers=headers, method="POST")
    +            try:
    +                urllib.request.urlopen(reviewers_req, timeout=30)
    +            except urllib.error.HTTPError:
    +                pass
    +
             return pr_url or ""
     
         def _find_existing_pr_url(self, repo: str, token: str, head: str, base: str) -> str:
    commit 886a2f2b404c2707009653f7c00ee1e602ae0e79
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Wed Sep 17 22:35:02 2025 -0400
    
        Update PR reviewer env var to PR_REVIEWER
        
        Renames the 'pr_reviewer' environment variable to 'PR_REVIEWER' for consistency and updates its usage to check both self.env and os.environ. This change ensures the correct environment variable is used when assigning a GitHub PR reviewer.
    
    commit b768ab626de80a8e273e379dca8953245e11f990
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Wed Sep 17 22:17:32 2025 -0400
    
        Add support for assigning PR reviewer
        
        Introduces a new 'pr_reviewer' input to specify a GitHub username to be assigned as a pull request reviewer. The PR creation logic now includes an API call to request a reviewer if provided.
    

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Processor FleetGitOpsUploader contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader.py
    diff --git a/FleetGitOpsUploader.py b/FleetGitOpsUploader.py
    index 9cb676d..7cb5534 100644
    --- a/FleetGitOpsUploader.py
    +++ b/FleetGitOpsUploader.py
    @@ -178,6 +178,12 @@ class FleetGitOpsUploader(Processor):
                 "description": "List of GitHub PR labels to apply.",
             },
     
    +        "PR_REVIEWER": {
    +            "required": False,
    +            "default": "",
    +            "description": "GitHub username to assign as PR reviewer.",
    +        },
    +
             # Slug / naming
             "software_slug": {
                 "required": False,
    @@ -272,7 +278,11 @@ class FleetGitOpsUploader(Processor):
                     "GitHub token not provided (github_token or FLEET_GITOPS_GITHUB_TOKEN env)."
                 )
             pr_labels = list(self.env.get("pr_labels", []))
    +
    +
             branch_prefix = self.env.get("branch_prefix", "").strip()
    +        pr_reviewer = self.env.get("PR_REVIEWER", "") or os.environ.get("PR_REVIEWER", "")
    +        pr_reviewer = pr_reviewer.strip()
     
             # Slug
             software_slug = self.env.get("software_slug", "").strip() or self._slugify(software_title)
    @@ -392,6 +402,7 @@ class FleetGitOpsUploader(Processor):
                 self._git(["push", "--set-upstream", "origin", branch_name], cwd=repo_dir)
     
             # Open PR
    +
             pr_url = self._open_pull_request(
                 github_repo=github_repo,
                 github_token=github_token,
    @@ -400,6 +411,7 @@ class FleetGitOpsUploader(Processor):
                 title=f"{software_title} {returned_version}",
                 body=self._pr_body(software_title, returned_version, software_slug, title_id, installer_id),
                 labels=pr_labels,
    +            reviewer=pr_reviewer,
             )
     
             # Outputs
    @@ -653,6 +665,7 @@ class FleetGitOpsUploader(Processor):
             title: str,
             body: str,
             labels: list[str],
    +        reviewer: str = "",
         ) -> str:
             api = f"https://api.github.com/repos/{github_repo}/pulls"
             headers = {
    @@ -689,6 +702,16 @@ class FleetGitOpsUploader(Processor):
                 except urllib.error.HTTPError:
                     pass
     
    +        # Assign reviewer if provided
    +        if reviewer and pr_url and "number" in pr:
    +            reviewers_api = f"https://api.github.com/repos/{github_repo}/pulls/{pr['number']}/requested_reviewers"
    +            reviewers_data = json.dumps({"reviewers": [reviewer]}).encode()
    +            reviewers_req = urllib.request.Request(reviewers_api, data=reviewers_data, headers=headers, method="POST")
    +            try:
    +                urllib.request.urlopen(reviewers_req, timeout=30)
    +            except urllib.error.HTTPError:
    +                pass
    +
             return pr_url or ""
     
         def _find_existing_pr_url(self, repo: str, token: str, head: str, base: str) -> str:
    commit 886a2f2b404c2707009653f7c00ee1e602ae0e79
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Wed Sep 17 22:35:02 2025 -0400
    
        Update PR reviewer env var to PR_REVIEWER
        
        Renames the 'pr_reviewer' environment variable to 'PR_REVIEWER' for consistency and updates its usage to check both self.env and os.environ. This change ensures the correct environment variable is used when assigning a GitHub PR reviewer.
    
    commit b768ab626de80a8e273e379dca8953245e11f990
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Wed Sep 17 22:17:32 2025 -0400
    
        Add support for assigning PR reviewer
        
        Introduces a new 'pr_reviewer' input to specify a GitHub username to be assigned as a pull request reviewer. The PR creation logic now includes an API call to request a reviewer if provided.
    
