### PR TITLE
Update trust for GitHub Desktop Google Chrome Caffeine

### DIFF
--- a/overrides/Caffeine.fleet.recipe.yaml
+++ b/overrides/Caffeine.fleet.recipe.yaml
@@ -4,18 +4,19 @@ Input:
 ParentRecipe: com.github.kitzy.fleet.Caffeine
 ParentRecipeTrustInfo:
   non_core_processors:
-    FleetGitOpsUploader:
-      path: ""
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+    com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader:
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
+      sha256_hash: 5b0b0c72afe4bcf2cdf0e9c8bbc39cf37af848b2edc501bc34af112810e76745
   parent_recipes:
     com.github.homebysix.pkg.Caffeine:
       git_hash: 13fe4fea20b645bfd9264124c0b96bdc1b9f6687
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Caffeine/Caffeine.pkg.recipe
       sha256_hash: ac31ef8b28f1f586aec3b788ae4c74278d174c692e1e1063c9f5ebea9cc9fa48
     com.github.kitzy.fleet.Caffeine:
-      git_hash: 933ab12388d1ec3d88d7b06b8a7a836861d9f294
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Caffeine/Caffeine.fleet.recipe.yaml
-      sha256_hash: ecb5381d8038084100f4b5a746392c4ceafc20745ea184559f694d2d61386b0c
+      sha256_hash: cbae642a0c32fbe4eb58b6c3c59f5a7b6d2307cd548355c98eced7ac208c9aa6
     com.github.peetinc.download.Caffeine:
       git_hash: 422113e2c5b9eab704721efed3aee4a9b6882069
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.peetinc-recipes/Caffeine/Caffeine.download.recipe

--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -6,9 +6,10 @@ Input:
 ParentRecipe: com.github.kitzy.fleet.GithubDesktop
 ParentRecipeTrustInfo:
   non_core_processors:
-    FleetGitOpsUploader:
-      path: ""
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+    com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader:
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
+      sha256_hash: 5b0b0c72afe4bcf2cdf0e9c8bbc39cf37af848b2edc501bc34af112810e76745
   parent_recipes:
     com.github.homebysix.download.GitHubDesktop:
       git_hash: 929f09a8dc248349e9ce35f7d519c253298317d1
@@ -19,6 +20,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.pkg.recipe
       sha256_hash: 8bfa208120d6372efa61b1043046f6a08ef896e0d4c07a0853cd3f532026c798
     com.github.kitzy.fleet.GithubDesktop:
-      git_hash: 933ab12388d1ec3d88d7b06b8a7a836861d9f294
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GitHub/GithubDesktop.fleet.recipe.yaml
-      sha256_hash: e433db608824efd8ac6a03544b2cb07a0558fe0383adfe128716bd30effef98c
+      sha256_hash: ab7b49c48e3325149609afa8c3a5eb8a26814f639d6fbc3c29545388ead24a5e

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -5,9 +5,10 @@ Input:
 ParentRecipe: com.github.kitzy.fleet.GoogleChrome
 ParentRecipeTrustInfo:
   non_core_processors:
-    FleetGitOpsUploader:
-      path: ""
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+    com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader:
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
+      sha256_hash: 5b0b0c72afe4bcf2cdf0e9c8bbc39cf37af848b2edc501bc34af112810e76745
   parent_recipes:
     com.github.autopkg.download.googlechrome:
       git_hash: 6f8bd33df3f7ab53eb679749eae8f04227790652
@@ -18,6 +19,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.pkg.recipe
       sha256_hash: 5acdf716353ccc57f021008bc5b4b55a5cb4e578e0f96864b71d4d2d29742ec8
     com.github.kitzy.fleet.GoogleChrome:
-      git_hash: 933ab12388d1ec3d88d7b06b8a7a836861d9f294
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google/GoogleChrome.fleet.recipe.yaml
-      sha256_hash: 3ca5a8c0d2572ee286774c35c18eae6a2ec179b9c77596307ca2f5777f4f2053
+      sha256_hash: 7944865db041b6850c9bb7242f4ac4629bb6b78f91684bce67aacf85cae2f29d


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Expected processor FleetGitOpsUploader can't be found.
    Unexpected processor found: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
    Parent recipe com.github.kitzy.fleet.GithubDesktop contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GitHub/GithubDesktop.fleet.recipe.yaml
    commit be76042d6797c8eec9ffb7e7c486711ad6628900
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 18:11:26 2025 -0400
    
        🎯 Fix AutoPkg processor discovery - CRITICAL UPDATE (#30)
        
        * Restructure processor to follow AutoPkg conventions
        
        - Move FleetGitOpsUploader.py and .recipe to their own directory
        - Follow the same pattern as other AutoPkg processors (e.g., FindAndReplace/)
        - Keep processors/ directory for potential future processors
        - This should make the processor discoverable by AutoPkg
        
        * Fix duplicated XML content in processor stub recipe
        
        - Remove duplicate XML headers and content that was causing malformed plist
        - Ensure proper XML format matching AutoPkg conventions
        - This should make the processor properly discoverable by AutoPkg
        
        * Remove old processors directory
        
        - The individual FleetGitOpsUploader/ directory is now the canonical location
        - Remove the old processors/ directory that had malformed XML
        - This should resolve the plist parsing errors and allow processor discovery
        
        * Fix processor discovery and update all recipe references
        
        ✅ BREAKTHROUGH: Processor discovery issue resolved!
        
        Changes:
        - Updated all recipe files to use correct processor reference format
        - Use 'com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader' instead of 'FleetGitOpsUploader'
        - Followed AutoPkg convention: repo.identifier/ProcessorName/ProcessorName
        - Tested successfully with GoogleChrome recipe - processor now found and executes
        
        The processor now works correctly. Only missing environment variables
        prevent complete execution, which is expected for testing without Fleet setup.
        
        Fixed recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        * Fix GitHub Actions workflows for new processor directory structure
        
        - Update paths from processors/ to FleetGitOpsUploader/
        - Fix processor name validation to accept full identifier format
        - Update Python import paths for integration tests
        - Ensure all CI checks work with restructured processor layout
        
        This resolves the failing CI checks that were looking for files
        in the old processors/ directory.
    diff --git a/GitHub/GithubDesktop.fleet.recipe.yaml b/GitHub/GithubDesktop.fleet.recipe.yaml
    index 47a7071..b58104a 100644
    --- a/GitHub/GithubDesktop.fleet.recipe.yaml
    +++ b/GitHub/GithubDesktop.fleet.recipe.yaml
    @@ -42,4 +42,4 @@ Process:
         branch_prefix: "%FLEET_BRANCH_PREFIX%"
         pr_labels: "%FLEET_PR_LABELS%"
         PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Expected processor FleetGitOpsUploader can't be found.
    Unexpected processor found: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
    Parent recipe com.github.kitzy.fleet.GoogleChrome contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google/GoogleChrome.fleet.recipe.yaml
    commit be76042d6797c8eec9ffb7e7c486711ad6628900
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 18:11:26 2025 -0400
    
        🎯 Fix AutoPkg processor discovery - CRITICAL UPDATE (#30)
        
        * Restructure processor to follow AutoPkg conventions
        
        - Move FleetGitOpsUploader.py and .recipe to their own directory
        - Follow the same pattern as other AutoPkg processors (e.g., FindAndReplace/)
        - Keep processors/ directory for potential future processors
        - This should make the processor discoverable by AutoPkg
        
        * Fix duplicated XML content in processor stub recipe
        
        - Remove duplicate XML headers and content that was causing malformed plist
        - Ensure proper XML format matching AutoPkg conventions
        - This should make the processor properly discoverable by AutoPkg
        
        * Remove old processors directory
        
        - The individual FleetGitOpsUploader/ directory is now the canonical location
        - Remove the old processors/ directory that had malformed XML
        - This should resolve the plist parsing errors and allow processor discovery
        
        * Fix processor discovery and update all recipe references
        
        ✅ BREAKTHROUGH: Processor discovery issue resolved!
        
        Changes:
        - Updated all recipe files to use correct processor reference format
        - Use 'com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader' instead of 'FleetGitOpsUploader'
        - Followed AutoPkg convention: repo.identifier/ProcessorName/ProcessorName
        - Tested successfully with GoogleChrome recipe - processor now found and executes
        
        The processor now works correctly. Only missing environment variables
        prevent complete execution, which is expected for testing without Fleet setup.
        
        Fixed recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        * Fix GitHub Actions workflows for new processor directory structure
        
        - Update paths from processors/ to FleetGitOpsUploader/
        - Fix processor name validation to accept full identifier format
        - Update Python import paths for integration tests
        - Ensure all CI checks work with restructured processor layout
        
        This resolves the failing CI checks that were looking for files
        in the old processors/ directory.
    diff --git a/Google/GoogleChrome.fleet.recipe.yaml b/Google/GoogleChrome.fleet.recipe.yaml
    index 332b24e..311f529 100644
    --- a/Google/GoogleChrome.fleet.recipe.yaml
    +++ b/Google/GoogleChrome.fleet.recipe.yaml
    @@ -39,4 +39,4 @@ Process:
         branch_prefix: "%FLEET_BRANCH_PREFIX%"
         pr_labels: "%FLEET_PR_LABELS%"
         PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    

overrides/Caffeine.fleet.recipe.yaml: FAILED
    Expected processor FleetGitOpsUploader can't be found.
    Unexpected processor found: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
    Parent recipe com.github.kitzy.fleet.Caffeine contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Caffeine/Caffeine.fleet.recipe.yaml
    commit be76042d6797c8eec9ffb7e7c486711ad6628900
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 18:11:26 2025 -0400
    
        🎯 Fix AutoPkg processor discovery - CRITICAL UPDATE (#30)
        
        * Restructure processor to follow AutoPkg conventions
        
        - Move FleetGitOpsUploader.py and .recipe to their own directory
        - Follow the same pattern as other AutoPkg processors (e.g., FindAndReplace/)
        - Keep processors/ directory for potential future processors
        - This should make the processor discoverable by AutoPkg
        
        * Fix duplicated XML content in processor stub recipe
        
        - Remove duplicate XML headers and content that was causing malformed plist
        - Ensure proper XML format matching AutoPkg conventions
        - This should make the processor properly discoverable by AutoPkg
        
        * Remove old processors directory
        
        - The individual FleetGitOpsUploader/ directory is now the canonical location
        - Remove the old processors/ directory that had malformed XML
        - This should resolve the plist parsing errors and allow processor discovery
        
        * Fix processor discovery and update all recipe references
        
        ✅ BREAKTHROUGH: Processor discovery issue resolved!
        
        Changes:
        - Updated all recipe files to use correct processor reference format
        - Use 'com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader' instead of 'FleetGitOpsUploader'
        - Followed AutoPkg convention: repo.identifier/ProcessorName/ProcessorName
        - Tested successfully with GoogleChrome recipe - processor now found and executes
        
        The processor now works correctly. Only missing environment variables
        prevent complete execution, which is expected for testing without Fleet setup.
        
        Fixed recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        * Fix GitHub Actions workflows for new processor directory structure
        
        - Update paths from processors/ to FleetGitOpsUploader/
        - Fix processor name validation to accept full identifier format
        - Update Python import paths for integration tests
        - Ensure all CI checks work with restructured processor layout
        
        This resolves the failing CI checks that were looking for files
        in the old processors/ directory.
    diff --git a/Caffeine/Caffeine.fleet.recipe.yaml b/Caffeine/Caffeine.fleet.recipe.yaml
    index cf56c4b..873409e 100644
    --- a/Caffeine/Caffeine.fleet.recipe.yaml
    +++ b/Caffeine/Caffeine.fleet.recipe.yaml
    @@ -39,4 +39,4 @@ Process:
         branch_prefix: "%FLEET_BRANCH_PREFIX%"
         pr_labels: "%FLEET_PR_LABELS%"
         PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    
