### PR TITLE
Update trust for GitHub Desktop Google Chrome Caffeine

### DIFF
--- a/overrides/Caffeine.fleet.recipe.yaml
+++ b/overrides/Caffeine.fleet.recipe.yaml
@@ -14,9 +14,9 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Caffeine/Caffeine.pkg.recipe
       sha256_hash: ac31ef8b28f1f586aec3b788ae4c74278d174c692e1e1063c9f5ebea9cc9fa48
     com.github.kitzy.fleet.Caffeine:
-      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      git_hash: 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Caffeine/Caffeine.fleet.recipe.yaml
-      sha256_hash: cbae642a0c32fbe4eb58b6c3c59f5a7b6d2307cd548355c98eced7ac208c9aa6
+      sha256_hash: 5469842faceecd4feb58a083e7b002e0ea28a77b8694f82865787d74d34f57f5
     com.github.peetinc.download.Caffeine:
       git_hash: 422113e2c5b9eab704721efed3aee4a9b6882069
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.peetinc-recipes/Caffeine/Caffeine.download.recipe

--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -20,6 +20,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.pkg.recipe
       sha256_hash: 8bfa208120d6372efa61b1043046f6a08ef896e0d4c07a0853cd3f532026c798
     com.github.kitzy.fleet.GithubDesktop:
-      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      git_hash: 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GitHub/GithubDesktop.fleet.recipe.yaml
-      sha256_hash: ab7b49c48e3325149609afa8c3a5eb8a26814f639d6fbc3c29545388ead24a5e
+      sha256_hash: 9ae9b3eb9315437b9d9dc28d13865b7e74ffcb439d5ff69de66e94c5f473f2a7

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -19,6 +19,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.pkg.recipe
       sha256_hash: 5acdf716353ccc57f021008bc5b4b55a5cb4e578e0f96864b71d4d2d29742ec8
     com.github.kitzy.fleet.GoogleChrome:
-      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      git_hash: 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google/GoogleChrome.fleet.recipe.yaml
-      sha256_hash: 7944865db041b6850c9bb7242f4ac4629bb6b78f91684bce67aacf85cae2f29d
+      sha256_hash: 6bdaafd1735f3211030261cb331a08a435fd61e8bde62d7fd7c9f9dc55938e8a


### PR DESCRIPTION
overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Parent recipe com.github.kitzy.fleet.GithubDesktop contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GitHub/GithubDesktop.fleet.recipe.yaml
    commit 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 19:20:39 2025 -0400
    
        🎯 Simplify recipes to use only required variables (#31)
        
        * Simplify recipes to use only required variables
        
        ✅ Problem: AutoPkg was failing on variable substitution before reaching processor
        ✅ Solution: Remove optional variables from recipes, use processor defaults instead
        
        Changes:
        - Removed all optional variables from recipe Arguments sections
        - Keep only truly required variables:
          * pkg_path, software_title, version (from parent recipes)
          * fleet_api_base, fleet_api_token, team_id (Fleet API required)
          * git_repo_url, github_token, team_yaml_path (GitOps required)
        
        Benefits:
        - Recipes now work without defining every optional variable
        - Users can add optional variables via AutoPkg overrides as needed
        - Processor defaults handle missing optional values gracefully
        - Much cleaner and more maintainable recipe files
        
        Updated recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        Optional variables can still be used via overrides - see README for full list.
        
        * Fix CI validation for simplified required variables
        
        - Remove FLEET_GITOPS_AUTHOR_EMAIL from required variables check
        - Match validation to actual required variables in simplified recipes
        - This variable has a default value in the processor so it's optional
    diff --git a/GitHub/GithubDesktop.fleet.recipe.yaml b/GitHub/GithubDesktop.fleet.recipe.yaml
    index b58104a..908637c 100644
    --- a/GitHub/GithubDesktop.fleet.recipe.yaml
    +++ b/GitHub/GithubDesktop.fleet.recipe.yaml
    @@ -6,40 +6,18 @@ MinimumVersion: "2.0"
     ParentRecipe: com.github.homebysix.pkg.GitHubDesktop
     Process:
     - Arguments:
    -    # Parent recipe requirements
    -    build: "%GITHUB_DESKTOP_BUILD%"
    -    
         # Core package info (from parent recipe)
         pkg_path: "%pkg_path%"
         software_title: "%NAME%"
         version: "%version%"
         
    -    # Fleet API configuration
    +    # Fleet API configuration (required)
         fleet_api_base: "%FLEET_API_BASE%"
         fleet_api_token: "%FLEET_API_TOKEN%"
         team_id: "%FLEET_TEAM_ID%"
         
    -    # Software configuration
    -    platform: "%FLEET_PLATFORM%"
    -    software_slug: "%FLEET_SOFTWARE_SLUG%"
    -    automatic_install: "%FLEET_AUTOMATIC_INSTALL%"
    -    self_service: "%FLEET_SELF_SERVICE%"
    -    
    -    # Git/GitHub configuration
    +    # Git/GitHub configuration (required)
         git_repo_url: "%FLEET_GITOPS_REPO_URL%"
         github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
    -    git_base_branch: "%FLEET_GIT_BASE_BRANCH%"
    -    git_author_name: "%FLEET_GIT_AUTHOR_NAME%"
    -    git_author_email: "%FLEET_GITOPS_AUTHOR_EMAIL%"
    -    
    -    # GitOps file paths
         team_yaml_path: "%FLEET_TEAM_YAML_PATH%"
    -    software_dir: "%FLEET_SOFTWARE_DIR%"
    -    package_yaml_suffix: "%FLEET_PACKAGE_YAML_SUFFIX%"
    -    team_yaml_package_path_prefix: "%FLEET_TEAM_YAML_PACKAGE_PATH_PREFIX%"
    -    
    -    # Optional features
    -    branch_prefix: "%FLEET_BRANCH_PREFIX%"
    -    pr_labels: "%FLEET_PR_LABELS%"
    -    PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    

overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Parent recipe com.github.kitzy.fleet.GoogleChrome contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google/GoogleChrome.fleet.recipe.yaml
    commit 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 19:20:39 2025 -0400
    
        🎯 Simplify recipes to use only required variables (#31)
        
        * Simplify recipes to use only required variables
        
        ✅ Problem: AutoPkg was failing on variable substitution before reaching processor
        ✅ Solution: Remove optional variables from recipes, use processor defaults instead
        
        Changes:
        - Removed all optional variables from recipe Arguments sections
        - Keep only truly required variables:
          * pkg_path, software_title, version (from parent recipes)
          * fleet_api_base, fleet_api_token, team_id (Fleet API required)
          * git_repo_url, github_token, team_yaml_path (GitOps required)
        
        Benefits:
        - Recipes now work without defining every optional variable
        - Users can add optional variables via AutoPkg overrides as needed
        - Processor defaults handle missing optional values gracefully
        - Much cleaner and more maintainable recipe files
        
        Updated recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        Optional variables can still be used via overrides - see README for full list.
        
        * Fix CI validation for simplified required variables
        
        - Remove FLEET_GITOPS_AUTHOR_EMAIL from required variables check
        - Match validation to actual required variables in simplified recipes
        - This variable has a default value in the processor so it's optional
    diff --git a/Google/GoogleChrome.fleet.recipe.yaml b/Google/GoogleChrome.fleet.recipe.yaml
    index 311f529..8e2a330 100644
    --- a/Google/GoogleChrome.fleet.recipe.yaml
    +++ b/Google/GoogleChrome.fleet.recipe.yaml
    @@ -11,32 +11,13 @@ Process:
         software_title: "%NAME%"
         version: "%version%"
         
    -    # Fleet API configuration
    +    # Fleet API configuration (required)
         fleet_api_base: "%FLEET_API_BASE%"
         fleet_api_token: "%FLEET_API_TOKEN%"
         team_id: "%FLEET_TEAM_ID%"
         
    -    # Software configuration
    -    platform: "%FLEET_PLATFORM%"
    -    software_slug: "%FLEET_SOFTWARE_SLUG%"
    -    automatic_install: "%FLEET_AUTOMATIC_INSTALL%"
    -    self_service: "%FLEET_SELF_SERVICE%"
    -    
    -    # Git/GitHub configuration
    +    # Git/GitHub configuration (required)
         git_repo_url: "%FLEET_GITOPS_REPO_URL%"
         github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
    -    git_base_branch: "%FLEET_GIT_BASE_BRANCH%"
    -    git_author_name: "%FLEET_GIT_AUTHOR_NAME%"
    -    git_author_email: "%FLEET_GITOPS_AUTHOR_EMAIL%"
    -    
    -    # GitOps file paths
         team_yaml_path: "%FLEET_TEAM_YAML_PATH%"
    -    software_dir: "%FLEET_SOFTWARE_DIR%"
    -    package_yaml_suffix: "%FLEET_PACKAGE_YAML_SUFFIX%"
    -    team_yaml_package_path_prefix: "%FLEET_TEAM_YAML_PACKAGE_PATH_PREFIX%"
    -    
    -    # Optional features
    -    branch_prefix: "%FLEET_BRANCH_PREFIX%"
    -    pr_labels: "%FLEET_PR_LABELS%"
    -    PR_REVIEWER: "%PR_REVIEWER%"
       Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    

overrides/Caffeine.fleet.recipe.yaml: FAILED
    Parent recipe com.github.kitzy.fleet.Caffeine contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Caffeine/Caffeine.fleet.recipe.yaml
    commit 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 19:20:39 2025 -0400
    
        🎯 Simplify recipes to use only required variables (#31)
        
        * Simplify recipes to use only required variables
        
        ✅ Problem: AutoPkg was failing on variable substitution before reaching processor
        ✅ Solution: Remove optional variables from recipes, use processor defaults instead
        
        Changes:
        - Removed all optional variables from recipe Arguments sections
        - Keep only truly required variables:
          * pkg_path, software_title, version (from parent recipes)
          * fleet_api_base, fleet_api_token, team_id (Fleet API required)
          * git_repo_url, github_token, team_yaml_path (GitOps required)
        
        Benefits:
        - Recipes now work without defining every optional variable
        - Users can add optional variables via AutoPkg overrides as needed
        - Processor defaults handle missing optional values gracefully
        - Much cleaner and more maintainable recipe files
        
        Updated recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        Optional variables can still be used via overrides - see README for full list.
        
        * Fix CI validation for simplified required variables
        
        - Remove FLEET_GITOPS_AUTHOR_EMAIL from required variables check
        - Match validation to actual required variables in simplified recipes
        - This variable has a default value in the processor so it's optional
    diff --git a/Caffeine/Caffeine.fleet.recipe.yaml b/Caffeine/Caffeine.fleet.recipe.yaml
    index 873409e..008c215 100644
    --- a/Caffeine/Caffeine.fleet.recipe.yaml
    +++ b/Caffeine/Caffeine.fleet.recipe.yaml
    @@ -11,32 +11,13 @@ Process:
         software_title: "%NAME%"
         version: "%version%"
         
    -    # Fleet API configuration
    +    # Fleet API configuration (required)
         fleet_api_base: "%FLEET_API_BASE%"
         fleet_api_token: "%FLEET_API_TOKEN%"
         team_id: "%FLEET_TEAM_ID%"
         
    -    # Software configuration
    -    platform: "%FLEET_PLATFORM%"
    -    software_slug: "%FLEET_SOFTWARE_SLUG%"
    -    automatic_install: "%FLEET_AUTOMATIC_INSTALL%"
    -    self_service: "%FLEET_SELF_SERVICE%"
    -    
    -    # Git/GitHub configuration
    +    # Git/GitHub configuration (required)
         git_repo_url: "%FLEET_GITOPS_REPO_URL%"
         github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
    -    git_base_branch: "%FLEET_GIT_BASE_BRANCH%"
    -    git_author_name: "%FLEET_GIT_AUTHOR_NAME%"
    -    git_author_email: "%FLEET_GITOPS_AUTHOR_EMAIL%"
    -    
    -    # GitOps file paths
         team_yaml_path: "%FLEET_TEAM_YAML_PATH%"
    -    software_dir: "%FLEET_SOFTWARE_DIR%"
    -    package_yaml_suffix: "%FLEET_PACKAGE_YAML_SUFFIX%"
    -    team_yaml_package_path_prefix: "%FLEET_TEAM_YAML_PACKAGE_PATH_PREFIX%"
    -    
    -    # Optional features
    -    branch_prefix: "%FLEET_BRANCH_PREFIX%"
    -    pr_labels: "%FLEET_PR_LABELS%"
    -    PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    
