### PR TITLE
Update trust for GPG Suite

### DIFF
--- a/overrides/GPGSuite.fleet.recipe.yaml
+++ b/overrides/GPGSuite.fleet.recipe.yaml
@@ -5,18 +5,19 @@ Input:
 ParentRecipe: com.github.kitzy.fleet.GPGSuite
 ParentRecipeTrustInfo:
   non_core_processors:
-    FleetGitOpsUploader:
-      path: ''
-      sha256_hash: PROCESSOR FILEPATH NOT FOUND
+    com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader:
+      git_hash: be76042d6797c8eec9ffb7e7c486711ad6628900
+      path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
+      sha256_hash: 5b0b0c72afe4bcf2cdf0e9c8bbc39cf37af848b2edc501bc34af112810e76745
   parent_recipes:
     com.github.gerardkok.download.GPGSuite:
       git_hash: 0f868e1baf5baa2dcd06fcef8a9c2a6fd9bf5119
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes/GPGTools/GPGSuite.download.recipe
       sha256_hash: 627c799094cc97489b3f1fc15bd6f21810efad349f077a8b9e6419b0ce1b0513
     com.github.kitzy.fleet.GPGSuite:
-      git_hash: 933ab12388d1ec3d88d7b06b8a7a836861d9f294
+      git_hash: 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GPGSuite/GPGSuite.fleet.recipe.yaml
-      sha256_hash: d79fb176ed01f88acdd9fcb1e374b18e12b2eaa1257e34a19e4c5c64c8cae6be
+      sha256_hash: e102e62328d14d555a17dd393bdc51bb0fccb1af2a22db3d10c4ccf92999bb04
     com.github.kitzy.pkg.GPGSuite:
       git_hash: b16607390b8411ba8589b752962a2d4d716aeab2
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.kitzy-recipes/GPG Suite/GPGSuite.pkg.recipe


### PR DESCRIPTION
overrides/GPGSuite.fleet.recipe.yaml: FAILED
    Expected processor FleetGitOpsUploader can't be found.
    Unexpected processor found: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/FleetGitOpsUploader/FleetGitOpsUploader.py
    Parent recipe com.github.kitzy.fleet.GPGSuite contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GPGSuite/GPGSuite.fleet.recipe.yaml
    commit 6a57f150145b09d95e1bc184797b3bb0c9ac6f1d
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 19:20:39 2025 -0400
    
        🎯 Simplify recipes to use only required variables (#31)
        
        * Simplify recipes to use only required variables
        
        ✅ Problem: AutoPkg was failing on variable substitution before reaching processor
        ✅ Solution: Remove optional variables from recipes, use processor defaults instead
        
        Changes:
        - Removed all optional variables from recipe Arguments sections
        - Keep only truly required variables:
          * pkg_path, software_title, version (from parent recipes)
          * fleet_api_base, fleet_api_token, team_id (Fleet API required)
          * git_repo_url, github_token, team_yaml_path (GitOps required)
        
        Benefits:
        - Recipes now work without defining every optional variable
        - Users can add optional variables via AutoPkg overrides as needed
        - Processor defaults handle missing optional values gracefully
        - Much cleaner and more maintainable recipe files
        
        Updated recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        Optional variables can still be used via overrides - see README for full list.
        
        * Fix CI validation for simplified required variables
        
        - Remove FLEET_GITOPS_AUTHOR_EMAIL from required variables check
        - Match validation to actual required variables in simplified recipes
        - This variable has a default value in the processor so it's optional
    
    commit be76042d6797c8eec9ffb7e7c486711ad6628900
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 18:11:26 2025 -0400
    
        🎯 Fix AutoPkg processor discovery - CRITICAL UPDATE (#30)
        
        * Restructure processor to follow AutoPkg conventions
        
        - Move FleetGitOpsUploader.py and .recipe to their own directory
        - Follow the same pattern as other AutoPkg processors (e.g., FindAndReplace/)
        - Keep processors/ directory for potential future processors
        - This should make the processor discoverable by AutoPkg
        
        * Fix duplicated XML content in processor stub recipe
        
        - Remove duplicate XML headers and content that was causing malformed plist
        - Ensure proper XML format matching AutoPkg conventions
        - This should make the processor properly discoverable by AutoPkg
        
        * Remove old processors directory
        
        - The individual FleetGitOpsUploader/ directory is now the canonical location
        - Remove the old processors/ directory that had malformed XML
        - This should resolve the plist parsing errors and allow processor discovery
        
        * Fix processor discovery and update all recipe references
        
        ✅ BREAKTHROUGH: Processor discovery issue resolved!
        
        Changes:
        - Updated all recipe files to use correct processor reference format
        - Use 'com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader' instead of 'FleetGitOpsUploader'
        - Followed AutoPkg convention: repo.identifier/ProcessorName/ProcessorName
        - Tested successfully with GoogleChrome recipe - processor now found and executes
        
        The processor now works correctly. Only missing environment variables
        prevent complete execution, which is expected for testing without Fleet setup.
        
        Fixed recipes:
        - Google/GoogleChrome.fleet.recipe.yaml
        - Caffeine/Caffeine.fleet.recipe.yaml
        - Chef/ChefDK.fleet.recipe.yaml
        - GPGSuite/GPGSuite.fleet.recipe.yaml
        - GitHub/GithubDesktop.fleet.recipe.yaml
        - RubyMine/RubyMine.fleet.recipe.yaml
        
        * Fix GitHub Actions workflows for new processor directory structure
        
        - Update paths from processors/ to FleetGitOpsUploader/
        - Fix processor name validation to accept full identifier format
        - Update Python import paths for integration tests
        - Ensure all CI checks work with restructured processor layout
        
        This resolves the failing CI checks that were looking for files
        in the old processors/ directory.
    diff --git a/GPGSuite/GPGSuite.fleet.recipe.yaml b/GPGSuite/GPGSuite.fleet.recipe.yaml
    index 5cc32e5..559e2ef 100644
    --- a/GPGSuite/GPGSuite.fleet.recipe.yaml
    +++ b/GPGSuite/GPGSuite.fleet.recipe.yaml
    @@ -10,33 +10,14 @@ Process:
         pkg_path: "%pkg_path%"
         software_title: "%NAME%"
         version: "%version%"
    -
    -    # Fleet API configuration
    +    
    +    # Fleet API configuration (required)
         fleet_api_base: "%FLEET_API_BASE%"
         fleet_api_token: "%FLEET_API_TOKEN%"
         team_id: "%FLEET_TEAM_ID%"
    -
    -    # Software configuration
    -    platform: "%FLEET_PLATFORM%"
    -    software_slug: "%FLEET_SOFTWARE_SLUG%"
    -    automatic_install: "%FLEET_AUTOMATIC_INSTALL%"
    -    self_service: "%FLEET_SELF_SERVICE%"
    -
    -    # Git/GitHub configuration
    +    
    +    # Git/GitHub configuration (required)
         git_repo_url: "%FLEET_GITOPS_REPO_URL%"
         github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
    -    git_base_branch: "%FLEET_GIT_BASE_BRANCH%"
    -    git_author_name: "%FLEET_GIT_AUTHOR_NAME%"
    -    git_author_email: "%FLEET_GITOPS_AUTHOR_EMAIL%"
    -
    -    # GitOps file paths
         team_yaml_path: "%FLEET_TEAM_YAML_PATH%"
    -    software_dir: "%FLEET_SOFTWARE_DIR%"
    -    package_yaml_suffix: "%FLEET_PACKAGE_YAML_SUFFIX%"
    -    team_yaml_package_path_prefix: "%FLEET_TEAM_YAML_PACKAGE_PATH_PREFIX%"
    -
    -    # Optional features
    -    branch_prefix: "%FLEET_BRANCH_PREFIX%"
    -    pr_labels: "%FLEET_PR_LABELS%"
    -    PR_REVIEWER: "%PR_REVIEWER%"
    -  Processor: FleetGitOpsUploader
    \ No newline at end of file
    +  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    
