### PR TITLE
Update trust for Zoom

### DIFF
--- a/overrides/Zoom.fleet.recipe.yaml
+++ b/overrides/Zoom.fleet.recipe.yaml
@@ -22,6 +22,6 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Zoom/Zoom.pkg.recipe
       sha256_hash: 016702213ba03e795107961d41e13173c2d5a95476c74ba9f2b596c1c441c9ff
     com.github.kitzy.fleet.Zoom:
-      git_hash: e1ef8ab51c2cb1f06d90bd2df91a2708b562e6f5
+      git_hash: 85ad760c96bdeb0d911e8b859fb2eef782fca74e
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Zoom/Zoom.fleet.recipe.yaml
-      sha256_hash: b3ffe9350f44445a1842e77832829356621b0a69cc4d8229b7cc24c7c0d4244a
+      sha256_hash: 62c291dce715f2d0a7f9ab85f8b08189f98815bdb5c98d6959108adb6691981e


### PR DESCRIPTION
overrides/Zoom.fleet.recipe.yaml: FAILED
    Parent recipe com.github.kitzy.fleet.Zoom contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Zoom/Zoom.fleet.recipe.yaml
    commit 85ad760c96bdeb0d911e8b859fb2eef782fca74e
    Author: Kitzy <kitzy@kitzy.com>
    Date:   Sat Sep 20 21:03:46 2025 -0400
    
        fix: Correct FleetGitOpsUploader processor arguments
        
        🔧 Fix Missing Required Arguments:
        - Add missing 'software_title' argument (was causing Zoom recipe failure)
        - Add missing 'pkg_path' and 'version' arguments
        - Use correct variable names matching working recipes
        
        🔄 Standardize Argument Names:
        - fleet_base_url → fleet_api_base
        - gitops_github_token → github_token
        - gitops_repo_url → git_repo_url
        - gitops_teams → team_id
        - bundle_identifier → team_yaml_path
        
        ✅ Fixed Recipes (9 total):
        - Slack, Zoom, Docker Desktop, Firefox
        - 1Password CLI, 1Password8, Visual Studio Code
        - Notion, iTerm2
        
        All recipes now match the format of working recipes
        (Google Chrome, GitHub Desktop, etc.) and should pass CI.
    diff --git a/Zoom/Zoom.fleet.recipe.yaml b/Zoom/Zoom.fleet.recipe.yaml
    index c4dd052..38cc093 100644
    --- a/Zoom/Zoom.fleet.recipe.yaml
    +++ b/Zoom/Zoom.fleet.recipe.yaml
    @@ -6,10 +6,18 @@ MinimumVersion: '2.0'
     ParentRecipe: com.github.homebysix.pkg.Zoom
     Process:
     - Arguments:
    +    # Core package info (from parent recipe)
    +    pkg_path: '%pkg_path%'
    +    software_title: '%NAME%'
    +    version: '%version%'
    +    
    +    # Fleet API configuration (required)
    +    fleet_api_base: '%FLEET_API_BASE%'
         fleet_api_token: '%FLEET_API_TOKEN%'
    -    fleet_base_url: '%FLEET_BASE_URL%'
    -    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
    -    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
    -    gitops_teams: '%FLEET_GITOPS_TEAMS%'
    -    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
    +    team_id: '%FLEET_TEAM_ID%'
    +    
    +    # Git/GitHub configuration (required)
    +    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
    +    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
    +    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
       Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader
    \ No newline at end of file
    
