### PR TITLE
Remove unused FleetImporter shim for AutoPkg processing

### DIFF
--- a/overrides/FleetImporter.py
+++ b/overrides/FleetImporter.py
@@ -1,7 +1,0 @@
-"""Intentionally blank shim removed: see test for local stub.
-
-This file is kept minimal to avoid AutoPkg importing a local FleetImporter
-class. The upstream FleetImporter processor will be used during runs.
-"""
-
-# No-op: upstream processor should be resolved via AutoPkg repos.


### PR DESCRIPTION
Eliminate the unused shim to streamline the AutoPkg processing by relying on the upstream FleetImporter processor.