### PR TITLE
Update trust for GitHub Desktop Google Chrome Zoom

### DIFF
--- a/overrides/GithubDesktop.fleet.recipe.yaml
+++ b/overrides/GithubDesktop.fleet.recipe.yaml
@@ -16,9 +16,9 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.download.recipe
       sha256_hash: ddd466175cff624508787263a470f89b7c2dcc517e1d5cc381f59ec06c846012
     com.github.homebysix.pkg.GitHubDesktop:
-      git_hash: dab19d8c72d5b4d2bab35a25dfd43d2e4ab15173
+      git_hash: 0d565f5f4889452bbf8b2af22761f4116741d4e2
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.pkg.recipe
-      sha256_hash: 8bfa208120d6372efa61b1043046f6a08ef896e0d4c07a0853cd3f532026c798
+      sha256_hash: 063d53ac38fbca09b04ee56258b6135578b858213bbb28b298298c1de345136b
     com.github.kitzy.fleet.GithubDesktop:
       git_hash: 898cd44c4df8e8dfe19b2e583ee37b7a0f0a2863
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/GitHub/GithubDesktop.fleet.recipe.yaml

--- a/overrides/GoogleChrome.fleet.recipe.yaml
+++ b/overrides/GoogleChrome.fleet.recipe.yaml
@@ -15,9 +15,9 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.download.recipe
       sha256_hash: c1ff98fc5b70f0794bfa43ddb9e9a46c5c045786037790ae422f47e936de3126
     com.github.autopkg.pkg.googlechrome:
-      git_hash: f29f399c54adee7122e9fdc3c1ea7ed4c67388a4
+      git_hash: dac213359eb245c48828a78d945ba8e1737f6a72
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.pkg.recipe
-      sha256_hash: 5acdf716353ccc57f021008bc5b4b55a5cb4e578e0f96864b71d4d2d29742ec8
+      sha256_hash: 14cc800d4d3179b9a67f8c492dc40acebe4e135ebd556b1ef9580214a43e915c
     com.github.kitzy.fleet.GoogleChrome:
       git_hash: 898cd44c4df8e8dfe19b2e583ee37b7a0f0a2863
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Google/GoogleChrome.fleet.recipe.yaml

--- a/overrides/Zoom.fleet.recipe.yaml
+++ b/overrides/Zoom.fleet.recipe.yaml
@@ -18,9 +18,9 @@ ParentRecipeTrustInfo:
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes/Zoom/Zoom.download.recipe
       sha256_hash: 3c4a2f325de4d51163c93505dd134918c9b2cae5089f555d59fac62f14bce007
     com.github.homebysix.pkg.Zoom:
-      git_hash: 3fc6a51644cfa9b791d2ff3ab6434390b073131c
+      git_hash: 0d565f5f4889452bbf8b2af22761f4116741d4e2
       path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Zoom/Zoom.pkg.recipe
-      sha256_hash: 016702213ba03e795107961d41e13173c2d5a95476c74ba9f2b596c1c441c9ff
+      sha256_hash: e58254542c046d96f7d309ecd7760710057c5debd171b394fce75ee0466187b5
     com.github.kitzy.fleet.Zoom:
       git_hash: 898cd44c4df8e8dfe19b2e583ee37b7a0f0a2863
       path: ~/Library/AutoPkg/RecipeRepos/com.github.kitzy.fleet-autopkg-recipes/Zoom/Zoom.fleet.recipe.yaml


### PR DESCRIPTION
/Users/runner/work/autopkg-runner/autopkg-runner/overrides/GithubDesktop.fleet.recipe.yaml: FAILED
    Parent recipe com.github.homebysix.pkg.GitHubDesktop contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.pkg.recipe
    commit 0d565f5f4889452bbf8b2af22761f4116741d4e2
    Author: Elliot Jordan <elliot@elliotjordan.com>
    Date:   Sat Oct 4 09:32:31 2025 -0700
    
        Remove unused pkg_request options in PkgCreator
    diff --git a/GitHub/GitHubDesktop.pkg.recipe b/GitHub/GitHubDesktop.pkg.recipe
    index 396522e4..7710e7e8 100644
    --- a/GitHub/GitHubDesktop.pkg.recipe
    +++ b/GitHub/GitHubDesktop.pkg.recipe
    @@ -37,8 +37,6 @@
     					</array>
     					<key>id</key>
     					<string>%BUNDLE_ID%</string>
    -					<key>options</key>
    -					<string>purge_ds_store</string>
     					<key>pkgname</key>
     					<string>%NAME%-%BUILD%-%version%</string>
     					<key>pkgroot</key>
    

/Users/runner/work/autopkg-runner/autopkg-runner/overrides/GoogleChrome.fleet.recipe.yaml: FAILED
    Parent recipe com.github.autopkg.pkg.googlechrome contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.pkg.recipe
    commit dac213359eb245c48828a78d945ba8e1737f6a72
    Author: Elliot Jordan <elliot@elliotjordan.com>
    Date:   Sat Oct 4 09:32:21 2025 -0700
    
        Remove unused pkg_request options in PkgCreator
    diff --git a/GoogleChrome/GoogleChrome.pkg.recipe b/GoogleChrome/GoogleChrome.pkg.recipe
    index b7c3101..afe2b5c 100644
    --- a/GoogleChrome/GoogleChrome.pkg.recipe
    +++ b/GoogleChrome/GoogleChrome.pkg.recipe
    @@ -62,8 +62,6 @@
                         <string>%version%</string>
                         <key>id</key>
                         <string>%bundleid%</string>
    -                    <key>options</key>
    -                    <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>
    

/Users/runner/work/autopkg-runner/autopkg-runner/overrides/Zoom.fleet.recipe.yaml: FAILED
    Parent recipe com.github.homebysix.pkg.Zoom contents differ from expected.
        Path: /Users/runner/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Zoom/Zoom.pkg.recipe
    commit 0d565f5f4889452bbf8b2af22761f4116741d4e2
    Author: Elliot Jordan <elliot@elliotjordan.com>
    Date:   Sat Oct 4 09:32:31 2025 -0700
    
        Remove unused pkg_request options in PkgCreator
    diff --git a/Zoom/Zoom.pkg.recipe b/Zoom/Zoom.pkg.recipe
    index 64c34371..7fea4de5 100644
    --- a/Zoom/Zoom.pkg.recipe
    +++ b/Zoom/Zoom.pkg.recipe
    @@ -91,8 +91,6 @@
     					</array>
     					<key>id</key>
     					<string>%BUNDLE_ID%</string>
    -					<key>options</key>
    -					<string>purge_ds_store</string>
     					<key>pkgname</key>
     					<string>%NAME%-%version%</string>
     					<key>scripts</key>
    
